### PR TITLE
Fixed document loading sequence

### DIFF
--- a/ods/Book.cpp
+++ b/ods/Book.cpp
@@ -190,12 +190,28 @@ Book::Load(const QString &full_path)
 	{
 		if (path.endsWith(ods::filename::ContentXml)) {
 			LoadContentXml(path);
-		} else if (path.endsWith(ods::filename::ManifestXml)) {
+			break;
+		}
+	}
+	for (auto path : extracted_file_paths_)
+	{
+		if (path.endsWith(ods::filename::ManifestXml)) {
 			LoadManifestXml(path);
-		} else if (path.endsWith(ods::filename::MetaXml)) {
+			break;
+		}
+	}
+	for (auto path : extracted_file_paths_)
+	{
+		if (path.endsWith(ods::filename::MetaXml)) {
 			LoadMetaXml(path);
-		} else if (path.endsWith(ods::filename::StylesXml)) {
+			break;
+		}
+	}
+	for (auto path : extracted_file_paths_)
+	{
+		if (path.endsWith(ods::filename::StylesXml)) {
 			LoadStylesXml(path);
+			break;
 		}
 	}
 }


### PR DESCRIPTION
Ods2 requires that document parts must be loaded in certain order, but the procedure that reads unpacked XML breaks that order and crashes due to uninitialized pointers. This is now fixed.